### PR TITLE
add editconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+!.*
+node_modules/*
+coverage/
+public/
+dist/
+stories.jsx

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,15 @@
 {
-  "extends": "react-app"
+  "extends": "react-app",
+  "rules": {
+    "comma-dangle": [2,"always-multiline"],
+    "no-else-return": 2,
+    "no-nested-ternary": 2,
+    "semi": [2,"never"],
+    "no-var": 2,
+    "object-shorthand": [2,"always"],
+    "prefer-const": 2,
+    "prefer-spread": 2,
+    "no-lonely-if": 2,
+    "no-unneeded-ternary": 2
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ typings/
 
 #webstorm cofig files
 .idea
-.editorconfig
 
 #ignored css files
 src/styles/css/app.css

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "sass-watch": "sass --watch src/styles/scss/index.scss:src/styles/css/index.css src/styles/scss/storybook.scss:src/styles/css/storybook.css",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public",
-    "query-tokens": "node src/scripts/queryTokens.js"
+    "query-tokens": "node src/scripts/queryTokens.js",
+    "lint": "eslint src/**/*.{js,jsx} --fix"
   },
   "dependencies": {
     "@amcharts/amcharts3-react": "^3.1.0",


### PR DESCRIPTION
1. Due to the inconsistency of indentation styles over different repos, EditorConfig is necessary to eliminate manual configuration for each projects
2. Enforce some common eslint rules for consistency

[EditorConfig](https://editorconfig.org/)