### PR TITLE
Quick Fix Issue Pair Is Undefined When Updating OHLCV

### DIFF
--- a/src/store/models/socketController.js
+++ b/src/store/models/socketController.js
@@ -512,6 +512,11 @@ const handleOHLCVMessage = (event: WebsocketEvent): ThunkAction => {
     }
 
     let ohlcv = event.payload
+    if (!Array.isArray(ohlcv)) {
+      // In case of INIT OHLCV, the payload is an array
+      // But in case of UPDATE OHLCV, the payload is an object
+      ohlcv = [ohlcv]
+    }
     const { pairName } = ohlcv[0].pair
     const pair = pairs[pairName]
 


### PR DESCRIPTION
This is a quick fix to solve below issue:

When initializing OHLCV data, server sends an array of object (multiple candles in the candlestick chart) to client.

But when updating OHLCV data through websocket, server only sends an individual object (one candle only)

Please check if the code is clear and provide a better solution if this pull request is not optimal.

Thank you.